### PR TITLE
Feature/confirm deposit and withdrawal

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,31 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+asgiref = "==3.8.1"
+django = "==5.1.6"
+django-cors-headers = "==4.7.0"
+django-environ = "==0.12.0"
+django-filter = "==25.1"
+django-jazzmin = "==3.0.1"
+djangorestframework = "==3.15.2"
+djangorestframework-simplejwt = "==5.5.0"
+drf-yasg = "==1.21.9"
+inflection = "==0.5.1"
+mysqlclient = "==2.2.7"
+packaging = "==24.2"
+pyjwt = "==2.9.0"
+python-dotenv = "==1.0.1"
+pytz = "==2025.1"
+pyyaml = "==6.0.2"
+sqlparse = "==0.5.3"
+tzdata = "==2025.1"
+uritemplate = "==4.1.1"
+whitenoise = "==6.9.0"
+
+[dev-packages]
+
+[requires]
+python_version = "3.11"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,257 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "4d2ceaa5f625959e150e44b6fe9f01fc29cd832dce2a8e2d5247d77663a983e6"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.11"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "asgiref": {
+            "hashes": [
+                "sha256:3e1e3ecc849832fe52ccf2cb6686b7a55f82bb1d6aee72a58826471390335e47",
+                "sha256:c343bd80a0bec947a9860adb4c432ffa7db769836c64238fc34bdc3fec84d590"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==3.8.1"
+        },
+        "django": {
+            "hashes": [
+                "sha256:1e39eafdd1b185e761d9fab7a9f0b9fa00af1b37b25ad980a8aa0dac13535690",
+                "sha256:8d203400bc2952fbfb287c2bbda630297d654920c72a73cc82a9ad7926feaad5"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.10'",
+            "version": "==5.1.6"
+        },
+        "django-cors-headers": {
+            "hashes": [
+                "sha256:6fdf31bf9c6d6448ba09ef57157db2268d515d94fc5c89a0a1028e1fc03ee52b",
+                "sha256:f1c125dcd58479fe7a67fe2499c16ee38b81b397463cf025f0e2c42937421070"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.9'",
+            "version": "==4.7.0"
+        },
+        "django-environ": {
+            "hashes": [
+                "sha256:227dc891453dd5bde769c3449cf4a74b6f2ee8f7ab2361c93a07068f4179041a",
+                "sha256:92fb346a158abda07ffe6eb23135ce92843af06ecf8753f43adf9d2366dcc0ca"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.9' and python_version < '4'",
+            "version": "==0.12.0"
+        },
+        "django-filter": {
+            "hashes": [
+                "sha256:1ec9eef48fa8da1c0ac9b411744b16c3f4c31176c867886e4c48da369c407153",
+                "sha256:4fa48677cf5857b9b1347fed23e355ea792464e0fe07244d1fdfb8a806215b80"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.9'",
+            "version": "==25.1"
+        },
+        "django-jazzmin": {
+            "hashes": [
+                "sha256:12a0a4c1d4fd09c2eef22acf6a1f03112b515ba695c59faa8ea80efc81c1f21b",
+                "sha256:67ae148bade41267a09ca8e4352ddefa6121795ebbac238bb9a6564ff841eb1b"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==3.0.1"
+        },
+        "djangorestframework": {
+            "hashes": [
+                "sha256:2b8871b062ba1aefc2de01f773875441a961fefbf79f5eed1e32b2f096944b20",
+                "sha256:36fe88cd2d6c6bec23dca9804bab2ba5517a8bb9d8f47ebc68981b56840107ad"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==3.15.2"
+        },
+        "djangorestframework-simplejwt": {
+            "hashes": [
+                "sha256:474a1b737067e6462b3609627a392d13a4da8a08b1f0574104ac6d7b1406f90e",
+                "sha256:4ef6b38af20cdde4a4a51d1fd8e063cbbabb7b45f149cc885d38d905c5a62edb"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.9'",
+            "version": "==5.5.0"
+        },
+        "drf-yasg": {
+            "hashes": [
+                "sha256:53d4319769bac121c56be18095342392b66d755e9fdd309414e1a86b5c3dd5ea",
+                "sha256:8548cdb072076c35064e57b11a6c955e47117605774b310b3aeab884256e9f19"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.6'",
+            "version": "==1.21.9"
+        },
+        "inflection": {
+            "hashes": [
+                "sha256:1a29730d366e996aaacffb2f1f1cb9593dc38e2ddd30c91250c6dde09ea9b417",
+                "sha256:f38b2b640938a4f35ade69ac3d053042959b62a0f1076a5bbaa1b9526605a8a2"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.5'",
+            "version": "==0.5.1"
+        },
+        "mysqlclient": {
+            "hashes": [
+                "sha256:199dab53a224357dd0cb4d78ca0e54018f9cee9bf9ec68d72db50e0a23569076",
+                "sha256:201a6faa301011dd07bca6b651fe5aaa546d7c9a5426835a06c3172e1056a3c5",
+                "sha256:24ae22b59416d5fcce7e99c9d37548350b4565baac82f95e149cac6ce4163845",
+                "sha256:2e3c11f7625029d7276ca506f8960a7fd3c5a0a0122c9e7404e6a8fe961b3d22",
+                "sha256:4b4c0200890837fc64014cc938ef2273252ab544c1b12a6c1d674c23943f3f2e",
+                "sha256:92af368ed9c9144737af569c86d3b6c74a012a6f6b792eb868384787b52bb585",
+                "sha256:977e35244fe6ef44124e9a1c2d1554728a7b76695598e4b92b37dc2130503069",
+                "sha256:a22d99d26baf4af68ebef430e3131bb5a9b722b79a9fcfac6d9bbf8a88800687"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==2.2.7"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759",
+                "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==24.2"
+        },
+        "pyjwt": {
+            "hashes": [
+                "sha256:3b02fb0f44517787776cf48f2ae25d8e14f300e6d7545a4315cee571a415e850",
+                "sha256:7e1e5b56cc735432a7369cbfa0efe50fa113ebecdc04ae6922deba8b84582d0c"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==2.9.0"
+        },
+        "python-dotenv": {
+            "hashes": [
+                "sha256:e324ee90a023d808f1959c46bcbc04446a10ced277783dc6ee09987c37ec10ca",
+                "sha256:f7b63ef50f1b690dddf550d03497b66d609393b40b564ed0d674909a68ebf16a"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==1.0.1"
+        },
+        "pytz": {
+            "hashes": [
+                "sha256:89dd22dca55b46eac6eda23b2d72721bf1bdfef212645d81513ef5d03038de57",
+                "sha256:c2db42be2a2518b28e65f9207c4d05e6ff547d1efa4086469ef855e4ab70178e"
+            ],
+            "index": "pypi",
+            "version": "==2025.1"
+        },
+        "pyyaml": {
+            "hashes": [
+                "sha256:01179a4a8559ab5de078078f37e5c1a30d76bb88519906844fd7bdea1b7729ff",
+                "sha256:0833f8694549e586547b576dcfaba4a6b55b9e96098b36cdc7ebefe667dfed48",
+                "sha256:0a9a2848a5b7feac301353437eb7d5957887edbf81d56e903999a75a3d743086",
+                "sha256:0b69e4ce7a131fe56b7e4d770c67429700908fc0752af059838b1cfb41960e4e",
+                "sha256:0ffe8360bab4910ef1b9e87fb812d8bc0a308b0d0eef8c8f44e0254ab3b07133",
+                "sha256:11d8f3dd2b9c1207dcaf2ee0bbbfd5991f571186ec9cc78427ba5bd32afae4b5",
+                "sha256:17e311b6c678207928d649faa7cb0d7b4c26a0ba73d41e99c4fff6b6c3276484",
+                "sha256:1e2120ef853f59c7419231f3bf4e7021f1b936f6ebd222406c3b60212205d2ee",
+                "sha256:1f71ea527786de97d1a0cc0eacd1defc0985dcf6b3f17bb77dcfc8c34bec4dc5",
+                "sha256:23502f431948090f597378482b4812b0caae32c22213aecf3b55325e049a6c68",
+                "sha256:24471b829b3bf607e04e88d79542a9d48bb037c2267d7927a874e6c205ca7e9a",
+                "sha256:29717114e51c84ddfba879543fb232a6ed60086602313ca38cce623c1d62cfbf",
+                "sha256:2e99c6826ffa974fe6e27cdb5ed0021786b03fc98e5ee3c5bfe1fd5015f42b99",
+                "sha256:39693e1f8320ae4f43943590b49779ffb98acb81f788220ea932a6b6c51004d8",
+                "sha256:3ad2a3decf9aaba3d29c8f537ac4b243e36bef957511b4766cb0057d32b0be85",
+                "sha256:3b1fdb9dc17f5a7677423d508ab4f243a726dea51fa5e70992e59a7411c89d19",
+                "sha256:41e4e3953a79407c794916fa277a82531dd93aad34e29c2a514c2c0c5fe971cc",
+                "sha256:43fa96a3ca0d6b1812e01ced1044a003533c47f6ee8aca31724f78e93ccc089a",
+                "sha256:50187695423ffe49e2deacb8cd10510bc361faac997de9efef88badc3bb9e2d1",
+                "sha256:5ac9328ec4831237bec75defaf839f7d4564be1e6b25ac710bd1a96321cc8317",
+                "sha256:5d225db5a45f21e78dd9358e58a98702a0302f2659a3c6cd320564b75b86f47c",
+                "sha256:6395c297d42274772abc367baaa79683958044e5d3835486c16da75d2a694631",
+                "sha256:688ba32a1cffef67fd2e9398a2efebaea461578b0923624778664cc1c914db5d",
+                "sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652",
+                "sha256:70b189594dbe54f75ab3a1acec5f1e3faa7e8cf2f1e08d9b561cb41b845f69d5",
+                "sha256:797b4f722ffa07cc8d62053e4cff1486fa6dc094105d13fea7b1de7d8bf71c9e",
+                "sha256:7c36280e6fb8385e520936c3cb3b8042851904eba0e58d277dca80a5cfed590b",
+                "sha256:7e7401d0de89a9a855c839bc697c079a4af81cf878373abd7dc625847d25cbd8",
+                "sha256:80bab7bfc629882493af4aa31a4cfa43a4c57c83813253626916b8c7ada83476",
+                "sha256:82d09873e40955485746739bcb8b4586983670466c23382c19cffecbf1fd8706",
+                "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563",
+                "sha256:8824b5a04a04a047e72eea5cec3bc266db09e35de6bdfe34c9436ac5ee27d237",
+                "sha256:8b9c7197f7cb2738065c481a0461e50ad02f18c78cd75775628afb4d7137fb3b",
+                "sha256:9056c1ecd25795207ad294bcf39f2db3d845767be0ea6e6a34d856f006006083",
+                "sha256:936d68689298c36b53b29f23c6dbb74de12b4ac12ca6cfe0e047bedceea56180",
+                "sha256:9b22676e8097e9e22e36d6b7bda33190d0d400f345f23d4065d48f4ca7ae0425",
+                "sha256:a4d3091415f010369ae4ed1fc6b79def9416358877534caf6a0fdd2146c87a3e",
+                "sha256:a8786accb172bd8afb8be14490a16625cbc387036876ab6ba70912730faf8e1f",
+                "sha256:a9f8c2e67970f13b16084e04f134610fd1d374bf477b17ec1599185cf611d725",
+                "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183",
+                "sha256:c70c95198c015b85feafc136515252a261a84561b7b1d51e3384e0655ddf25ab",
+                "sha256:cc1c1159b3d456576af7a3e4d1ba7e6924cb39de8f67111c735f6fc832082774",
+                "sha256:ce826d6ef20b1bc864f0a68340c8b3287705cae2f8b4b1d932177dcc76721725",
+                "sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e",
+                "sha256:d7fded462629cfa4b685c5416b949ebad6cec74af5e2d42905d41e257e0869f5",
+                "sha256:d84a1718ee396f54f3a086ea0a66d8e552b2ab2017ef8b420e92edbc841c352d",
+                "sha256:d8e03406cac8513435335dbab54c0d385e4a49e4945d2909a581c83647ca0290",
+                "sha256:e10ce637b18caea04431ce14fabcf5c64a1c61ec9c56b071a4b7ca131ca52d44",
+                "sha256:ec031d5d2feb36d1d1a24380e4db6d43695f3748343d99434e6f5f9156aaa2ed",
+                "sha256:ef6107725bd54b262d6dedcc2af448a266975032bc85ef0172c5f059da6325b4",
+                "sha256:efdca5630322a10774e8e98e1af481aad470dd62c3170801852d752aa7a783ba",
+                "sha256:f753120cb8181e736c57ef7636e83f31b9c0d1722c516f7e86cf15b7aa57ff12",
+                "sha256:ff3824dc5261f50c9b0dfb3be22b4567a6f938ccce4587b38952d85fd9e9afe4"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==6.0.2"
+        },
+        "sqlparse": {
+            "hashes": [
+                "sha256:09f67787f56a0b16ecdbde1bfc7f5d9c3371ca683cfeaa8e6ff60b4807ec9272",
+                "sha256:cf2196ed3418f3ba5de6af7e82c694a9fbdbfecccdfc72e281548517081f16ca"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==0.5.3"
+        },
+        "tzdata": {
+            "hashes": [
+                "sha256:24894909e88cdb28bd1636c6887801df64cb485bd593f2fd83ef29075a81d694",
+                "sha256:7e127113816800496f027041c570f50bcd464a020098a3b6b199517772303639"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '2'",
+            "version": "==2025.1"
+        },
+        "uritemplate": {
+            "hashes": [
+                "sha256:4346edfc5c3b79f694bccd6d6099a322bbeb628dbf2cd86eea55a456ce5124f0",
+                "sha256:830c08b8d99bdd312ea4ead05994a38e8936266f84b9a7878232db50b044e02e"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.6'",
+            "version": "==4.1.1"
+        },
+        "whitenoise": {
+            "hashes": [
+                "sha256:8c4a7c9d384694990c26f3047e118c691557481d624f069b7f7752a2f735d609",
+                "sha256:c8a489049b7ee9889617bb4c274a153f3d979e8f51d2efd0f5b403caf41c57df"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.9'",
+            "version": "==6.9.0"
+        }
+    },
+    "develop": {}
+}

--- a/api/permissions.py
+++ b/api/permissions.py
@@ -1,5 +1,15 @@
-from rest_framework.permissions import BasePermission
+from rest_framework import permissions
 
-class IsAuthenticated(BasePermission):
+
+class IsAuthenticated(permissions.BasePermission):
     def has_permission(self, request, view):
         return request.user and request.user.is_authenticated
+
+
+class IsOwnerOrReadOnly(permissions.IsAuthenticatedOrReadOnly):
+    """A user is allowed to modify their own object e.g deposit..."""
+
+    def has_object_permission(self, request, view, obj):
+        if request.method and request.method not in permissions.SAFE_METHODS:
+            return bool(obj.user == request.user)
+        return super().has_object_permission(request, view, obj)

--- a/api/views.py
+++ b/api/views.py
@@ -1,20 +1,21 @@
 from django.shortcuts import render
 from rest_framework import viewsets, serializers
 from rest_framework.response import Response
+from rest_framework import status
 from rest_framework.decorators import action
-from rest_framework.permissions import IsAuthenticated
+from rest_framework.permissions import IsAuthenticated,IsAdminUser
 from django_filters.rest_framework import DjangoFilterBackend
 from transactions.models import Deposit, Withdrawal, Balance
 from .serializers import DepositSerializer, WithdrawalSerializer, BalanceSerializer
 from .filters import DepositFilter, WithdrawalFilter
 from decimal import Decimal
-from django.core.exceptions import ValidationError
+from .permissions import IsOwnerOrReadOnly
 
 class DepositViewSet(viewsets.ModelViewSet):
     serializer_class = DepositSerializer
     filter_backends = [DjangoFilterBackend]
     filterset_class = DepositFilter
-    permission_classes = [IsAuthenticated]
+    permission_classes = [IsOwnerOrReadOnly]
 
     def get_queryset(self):
         return Deposit.objects.filter(user=self.request.user)
@@ -24,11 +25,7 @@ class DepositViewSet(viewsets.ModelViewSet):
         try:
             deposit = serializer.save(user=self.request.user)
             print(f"Deposit created: {deposit}")
-            balance, created = Balance.objects.get_or_create(user=deposit.user)
-            print(f"Balance retrieved/created: {balance}, created: {created}")
-            balance.amount += Decimal(deposit.amount)
-            balance.save()
-            print(f"Balance updated: {balance.amount}")
+
         except serializers.ValidationError as e:
             print(f"Validation errors: {e.detail}")
             return Response(e.detail, status=400)
@@ -37,28 +34,101 @@ class DepositViewSet(viewsets.ModelViewSet):
         print("Performing update for deposit")
         try:
             instance = self.get_object()
-            old_amount = instance.amount
+            old_amount = Decimal(instance.amount)
+            old_verified = instance.is_verified
+
+            # if the deposit that is to be updated is already verified, Not allowed
+            print(f"PREVIOUS DEPOSIT STATUS {old_verified} ")
+             # If the deposit is already verified, raise an error
+            if old_verified:
+                raise serializers.ValidationError("You can't update an already verified deposit.")
+
             new_instance = serializer.save(user=self.request.user)
-            print(f"Deposit updated: {new_instance}")
-            balance, created = Balance.objects.get_or_create(user=new_instance.user)
-            print(f"Balance retrieved/created: {balance}, created: {created}")
-            new_balance = balance.amount + Decimal(new_instance.amount) - Decimal(old_amount)
-            balance.amount = new_balance
-            balance.save()
-            print(f"Balance updated: {balance.amount}")
+            print(f"Deposit updated: {new_instance} , Verified: {new_instance.is_verified}")
+
+            new_amount = Decimal(new_instance.amount)
+            new_verified = new_instance.is_verified
+
+            value = Decimal(0)
+            # a user can only modify unverified deposit
+            if not (old_verified and new_verified):
+                print(not (old_verified or new_verified))
+                value = new_amount - old_amount
+
+            if value != 0:
+                balance, created = Balance.objects.get_or_create(user=new_instance.user)
+                print(f"Balance retrieved/created: {balance}, created: {created}")
+                balance.amount += value
+                balance.save()
+                print(f"Balance updated: {balance.amount}")
+    
         except serializers.ValidationError as e:
             print(f"Validation errors: {e.detail}")
             return Response(e.detail, status=400)
 
-    def perform_destroy(self, instance):
-        print("Performing destroy for deposit")
-        balance, created = Balance.objects.get_or_create(user=instance.user)
-        print(f"Balance retrieved/created: {balance}, created: {created}")
-        balance.amount -= Decimal(instance.amount)
-        balance.save()
-        print(f"Balance updated: {balance.amount}")
-        instance.delete()
-        print("Deposit deleted")
+
+    def destroy(self, request, *args, **kwargs):
+        """ 
+        Overwrites the default destroy method. We want to make sure only staff can delete 
+        a verified post and while use can delete their own unverified deposit
+        """
+        print("performing Delete for deposit")
+
+        try:
+            instance = self.get_object()
+
+            if instance.is_verified and not request.user.is_staff:
+                return Response(
+                            {"detail": "You can't delete an already verified deposit."},
+                            status=status.HTTP_403_FORBIDDEN,
+                        )
+
+            balance = Balance.objects.get(user=instance.user)
+            balance.amount -= Decimal(instance.amount)
+            balance.save()
+            print(f"Balance updated by subtracting {instance.amount}. New balance: {balance.amount}, Deleted by: {request.user.is_staff}")
+
+            # Delete the deposit
+            instance.delete()
+            print("Deposit deleted")
+
+            return Response(
+                    {"detail": "Deposit deleted successfully."},
+                    status=status.HTTP_204_NO_CONTENT,
+                )
+        except Exception as e:
+            print(f"Deposit not verified: {e}")
+            return Response(e, status=status.HTTP_400_BAD_REQUEST)
+
+    @action(detail=True, methods=['GET'] , permission_classes=[IsAdminUser])
+    def verify(self, request, pk):
+        """ Verify the status of a deposit by a staff"""
+        try:
+            deposit = Deposit.objects.get(id=pk)
+            if deposit.is_verified:
+                return Response(
+                    data={"message": "Deposit is initially verified!"},
+                    status=status.HTTP_400_BAD_REQUEST
+                    )
+
+            # not verified
+            deposit.is_verified = True
+            deposit.save()
+            print(f"Deposit verified successfully amount {deposit.amount}")
+
+            balance, created = Balance.objects.get_or_create(user=deposit.user)
+            balance.amount += Decimal(deposit.amount)
+            balance.save()
+            print(f"Balance updated successfully new amount {deposit.amount},first time depositing:{created}")
+
+            return Response(
+                data={"message": "Deposit verified successfully", "new balance": balance.amount},
+                status= status.HTTP_200_OK
+            )
+        except Exception as e:
+            print(f"Deposit not verified: {e}")
+            return Response(e, status=status.HTTP_400_BAD_REQUEST)
+
 
 class WithdrawalViewSet(viewsets.ModelViewSet):
     serializer_class = WithdrawalSerializer
@@ -109,17 +179,20 @@ class WithdrawalViewSet(viewsets.ModelViewSet):
         instance.delete()
         print("Withdrawal deleted")
 
+
 class BalanceViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = BalanceSerializer
     permission_classes = [IsAuthenticated]
 
     def get_queryset(self):
+        if self.request.user.is_staff:
+            return Balance.objects.all()
         return Balance.objects.filter(user=self.request.user)
 
     def list(self, request, *args, **kwargs):
         queryset = self.get_queryset()
         if (queryset.exists()):
-            serializer = self.get_serializer(queryset.first())
+            serializer = self.get_serializer(queryset,many=True)
             return Response(serializer.data)
         else:
             return Response({"id": None, "user": request.user.id, "amount": 0})

--- a/transactions/admin.py
+++ b/transactions/admin.py
@@ -15,6 +15,7 @@ class DepositAdmin(admin.ModelAdmin):
     list_per_page = 10
     list_filter = ("is_verified",)
     search_fields = ("user__username",)
+    ordering = ('timestamp','is_verified')
 
     class Meta:
         model = Deposit

--- a/transactions/admin.py
+++ b/transactions/admin.py
@@ -1,8 +1,20 @@
 from django.contrib import admin
 from .models import Deposit, Withdrawal, Balance
 
-admin.site.register(Deposit)
+# admin.site.register(Deposit)
 admin.site.register(Withdrawal)
 admin.site.register(Balance)
 
 # Register your models here.
+
+
+@admin.register(Deposit)
+class DepositAdmin(admin.ModelAdmin):
+    list_display = ("user", "amount", "is_verified")
+    list_editable = ("is_verified",)
+    list_per_page = 10
+    list_filter = ("is_verified",)
+    search_fields = ("user__username",)
+
+    class Meta:
+        model = Deposit

--- a/transactions/models.py
+++ b/transactions/models.py
@@ -1,7 +1,7 @@
 from django.db import models
 from django.conf import settings
 from django.core.exceptions import ValidationError
-
+from decimal import  Decimal
 
 class Balance(models.Model):
     user = models.OneToOneField(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
@@ -16,8 +16,46 @@ class Deposit(models.Model):
     is_verified = models.BooleanField(default=False)
     timestamp = models.DateTimeField(auto_now_add=True)
 
+    class Meta:
+        ordering = ("-timestamp","is_verified")
+
     def __str__(self):
         return f"{self.user.username} - Deposit - {self.amount}"
+
+    def save(self, *args, **kwargs):
+        """increase the balance if deposit is just verified and vice versa"""
+        try:
+            if self.pk:
+                old_deposit = Deposit.objects.get(pk=self.pk)
+                old_verified = old_deposit.is_verified
+                old_amount = Decimal(old_deposit.amount)
+
+                new_verified = self.is_verified
+                new_amount = Decimal(self.amount)
+
+                value = Decimal(0)
+
+                if old_verified and not new_verified:
+                    # we want to subtract from balance because we have added it when it was first verified
+                    value -= old_amount
+                    print(f'i am working on 1 block value:{value}')
+                if new_verified and not old_verified:
+                    value += new_amount
+                    print(f'i am working on 2 block value:{value}')
+                if new_verified and old_verified:
+                    value += new_amount - old_amount
+                    print(f'i am working on 3 block value:{value}')
+
+                balance, created = Balance.objects.get_or_create(user=old_deposit.user)
+                print(f'updating balance with {value}, new amount:{new_amount}, old amount : {old_amount}, Balance: {balance} ')
+                if value != 0:
+                    balance.amount += value
+                    balance.save()
+
+            super().save(*args, **kwargs)
+        except Exception as e:
+            raise ValidationError(f"An error occurred: {str(e)}")
+                
 
 
 class Withdrawal(models.Model):

--- a/transactions/models.py
+++ b/transactions/models.py
@@ -12,6 +12,7 @@ class Balance(models.Model):
 class Deposit(models.Model):
     user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
     amount = models.DecimalField(max_digits=10, decimal_places=2)
+    is_verified = models.BooleanField(default=False)
     timestamp = models.DateTimeField(auto_now_add=True)
 
     def __str__(self):
@@ -20,6 +21,7 @@ class Deposit(models.Model):
 class Withdrawal(models.Model):
     user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
     amount = models.DecimalField(max_digits=10, decimal_places=2)
+    is_verified = models.BooleanField(default=False)
     timestamp = models.DateTimeField(auto_now_add=True)
 
     def __str__(self):

--- a/transactions/models.py
+++ b/transactions/models.py
@@ -2,6 +2,7 @@ from django.db import models
 from django.conf import settings
 from django.core.exceptions import ValidationError
 
+
 class Balance(models.Model):
     user = models.OneToOneField(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
     amount = models.DecimalField(max_digits=10, decimal_places=2, default=0.00)
@@ -17,6 +18,7 @@ class Deposit(models.Model):
 
     def __str__(self):
         return f"{self.user.username} - Deposit - {self.amount}"
+
 
 class Withdrawal(models.Model):
     user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)


### PR DESCRIPTION
On this branch 

I have worked on the deposit confirm update features before balance increases.


Serializers:
I included the is_verified field  as `read_only_fields` to the Deposit serializers 

Model:
I modified the Deposit model `save` to add and subtract the amount for the deposit that was verified and unverified.

Admin:
Also I included the Deposit table to include amount and is_verified as editable field that give the admin the flexibility to bulk update deposits.

Views:

In the views I added an action (Verify)  to the `Deposit Viewset` that will allow only admin user to verify a deposit.
I changed the performs logic to stop the direct addition to balance.

`Balance Viewset`
I made change the queryset for admin user to see all balances.
